### PR TITLE
Rearrange code

### DIFF
--- a/bin/check-codeowners
+++ b/bin/check-codeowners
@@ -115,6 +115,101 @@ class OwnerEntry < Entry
   end
 end
 
+class GetOptions
+  def initialize(argv)
+    @debug = false
+    @show_json = false
+    @strict = false
+    @find_redundant_ignores = false
+    @who_owns = false
+    @files_owned = false
+    @check_unowned = false
+    @should_check_indent = true
+    @should_check_sorted = true
+    @should_check_valid_owners = true
+    read_options(argv)
+    validate
+  end
+
+  attr_reader :debug, :show_json, :strict, :find_redundant_ignores,
+    :who_owns, :files_owned,
+    :check_unowned, :should_check_indent, :should_check_sorted, :should_check_valid_owners,
+    :args
+
+  private
+
+  attr_writer :debug, :show_json, :strict, :find_redundant_ignores,
+    :who_owns, :files_owned,
+    :check_unowned, :should_check_indent, :should_check_sorted, :should_check_valid_owners,
+    :args
+
+  def read_options(argv)
+    parser = OptionParser.new do |opts|
+      opts.banner = "Usage: check-codeowners [options] [arguments]"
+
+      opts.on("-j", "--json", "Show results as JSON") do
+        self.show_json = true
+      end
+      opts.on("-s", "--strict", "Treat warnings as errors") do
+        self.strict = true
+      end
+      opts.on("-b", "--brute-force", "Find entries which do not match any files") do
+        self.find_redundant_ignores = true
+      end
+      opts.on("--no-check-indent", "Do not require equal indenting") do |value|
+        self.should_check_indent = value
+      end
+      opts.on("--no-check-sorted", "Do not require sorted entries") do |value|
+        self.should_check_sorted = value
+      end
+      opts.on("--no-check-valid-owners", "Do not check owners against VALIDOWNERS") do |value|
+        self.should_check_valid_owners = value
+      end
+      opts.on(
+        "--who-owns",
+        "Treat arguments as a list of files; show who owns each file, then exit." \
+        " If no arguments are given, all files are shown. Incompatible with" \
+        " --files-owned."
+      ) do
+        self.who_owns = true
+      end
+      opts.on(
+        "--files-owned",
+        "Treat arguments as a list of owners; show what files they own, then exit." \
+        " Incompatible with --who-owns."
+      ) do
+        self.files_owned = true
+      end
+      opts.on(
+        "--check-unowned",
+        "Checks if there are new files that are not owned"
+      ) do
+        self.check_unowned = true
+      end
+      opts.on("-d", "--debug", "Include debug output; implies --json") do
+        self.debug = true
+        self.show_json = true
+      end
+    end
+
+    argv = [*argv]
+    parser.parse!(argv)
+    @args = argv
+  end
+
+  def validate
+    if who_owns && files_owned
+      $stderr.puts "Invalid usage. Try check-codeowners --help"
+      exit 2
+    end
+
+    if !who_owns && !files_owned && args.any?
+      $stderr.puts "Invalid usage. Try check-codeowners --help"
+      exit 2
+    end
+  end
+end
+
 def parse_codeowners_file
   lines = begin
             IO.readlines(CODEOWNERS_PATH).map(&:chomp)
@@ -481,103 +576,6 @@ def show_checks_text(r)
   if r.errors.any? || r.warnings.any?
     puts "For help, see https://github.com/zendesk/setup-check-codeowners/blob/main/Usage.md"
   end
-end
-
-class GetOptions
-
-  def initialize(argv)
-    @debug = false
-    @show_json = false
-    @strict = false
-    @find_redundant_ignores = false
-    @who_owns = false
-    @files_owned = false
-    @check_unowned = false
-    @should_check_indent = true
-    @should_check_sorted = true
-    @should_check_valid_owners = true
-    read_options(argv)
-    validate
-  end
-
-  attr_reader :debug, :show_json, :strict, :find_redundant_ignores,
-    :who_owns, :files_owned,
-    :check_unowned, :should_check_indent, :should_check_sorted, :should_check_valid_owners,
-    :args
-
-  private
-
-  attr_writer :debug, :show_json, :strict, :find_redundant_ignores,
-    :who_owns, :files_owned,
-    :check_unowned, :should_check_indent, :should_check_sorted, :should_check_valid_owners,
-    :args
-
-  def read_options(argv)
-    parser = OptionParser.new do |opts|
-      opts.banner = "Usage: check-codeowners [options] [arguments]"
-
-      opts.on("-j", "--json", "Show results as JSON") do
-        self.show_json = true
-      end
-      opts.on("-s", "--strict", "Treat warnings as errors") do
-        self.strict = true
-      end
-      opts.on("-b", "--brute-force", "Find entries which do not match any files") do
-        self.find_redundant_ignores = true
-      end
-      opts.on("--no-check-indent", "Do not require equal indenting") do |value|
-        self.should_check_indent = value
-      end
-      opts.on("--no-check-sorted", "Do not require sorted entries") do |value|
-        self.should_check_sorted = value
-      end
-      opts.on("--no-check-valid-owners", "Do not check owners against VALIDOWNERS") do |value|
-        self.should_check_valid_owners = value
-      end
-      opts.on(
-        "--who-owns",
-        "Treat arguments as a list of files; show who owns each file, then exit." \
-        " If no arguments are given, all files are shown. Incompatible with" \
-        " --files-owned."
-      ) do
-        self.who_owns = true
-      end
-      opts.on(
-        "--files-owned",
-        "Treat arguments as a list of owners; show what files they own, then exit." \
-        " Incompatible with --who-owns."
-      ) do
-        self.files_owned = true
-      end
-      opts.on(
-        "--check-unowned",
-        "Checks if there are new files that are not owned"
-      ) do
-        self.check_unowned = true
-      end
-      opts.on("-d", "--debug", "Include debug output; implies --json") do
-        self.debug = true
-        self.show_json = true
-      end
-    end
-
-    argv = [*argv]
-    parser.parse!(argv)
-    @args = argv
-  end
-
-  def validate
-    if who_owns && files_owned
-      $stderr.puts "Invalid usage. Try check-codeowners --help"
-      exit 2
-    end
-
-    if !who_owns && !files_owned && args.any?
-      $stderr.puts "Invalid usage. Try check-codeowners --help"
-      exit 2
-    end
-  end
-
 end
 
 # MAIN START

--- a/bin/check-codeowners
+++ b/bin/check-codeowners
@@ -5,10 +5,6 @@ require 'set'
 require 'shellwords'
 require 'tempfile'
 
-CODEOWNERS_PATH = ".github/CODEOWNERS"
-CODEOWNERS_IGNORE_PATH = ".github/CODEOWNERS.ignore"
-VALIDOWNERS_PATH = ".github/VALIDOWNERS"
-
 class MultiGitLsRunner
   PREFIX_LENGTH = 6
 
@@ -210,76 +206,130 @@ class GetOptions
   end
 end
 
-def parse_codeowners_file
-  lines = begin
-            IO.readlines(CODEOWNERS_PATH).map(&:chomp)
-          rescue Errno::ENOENT
-            []
-          end
+class Parsers
+  def parse_codeowners_file(path)
+    lines = begin
+              IO.readlines(path).map(&:chomp)
+            rescue Errno::ENOENT
+              []
+            end
 
-  owner_re = /\S+/
+    owner_re = /\S+/
 
-  errors = []
+    errors = []
 
-  entries = lines.each_with_index.map do |line, index|
-    base = { line_number: index + 1, text: line, file: CODEOWNERS_PATH }
+    entries = lines.each_with_index.map do |line, index|
+      base = { line_number: index + 1, text: line, file: path }
 
-    case line
-    when "", /^#/
-      # Could be used in the future to reconstruct the file
-      Entry.new(base)
-    when /^((\S+)\s+)(#{owner_re}( #{owner_re})*)$/
-      base.merge!(pattern: $2, indent: ($1).length, owners: $3.split(' '))
-      OwnerEntry.new(base)
-    else
-      Entry.new(base).tap do |entry|
-        errors << {
-          code: "unrecognised_line",
-          message: "Unrecognised line at #{entry.file}:#{entry.line_number}",
-          entry: entry
-        }
+      case line
+      when "", /^#/
+        # Could be used in the future to reconstruct the file
+        Entry.new(base)
+      when /^((\S+)\s+)(#{owner_re}( #{owner_re})*)$/
+        base.merge!(pattern: $2, indent: ($1).length, owners: $3.split(' '))
+        OwnerEntry.new(base)
+      else
+        Entry.new(base).tap do |entry|
+          errors << {
+            code: "unrecognised_line",
+            message: "Unrecognised line at #{entry.file}:#{entry.line_number}",
+            entry: entry
+          }
+        end
       end
     end
+
+    Struct.new(:entries, :errors).new(entries, errors)
   end
 
-  Struct.new(:entries, :errors).new(entries, errors)
+  def parse_ignore_file(path, options)
+    lines = begin
+              IO.readlines(path).map(&:chomp)
+            rescue Errno::ENOENT
+              []
+            end
+
+    patterns = Set.new
+    files = Set.new
+    previous_line = nil
+
+    errors = []
+
+    lines.each_with_index do |line, index|
+      next if line.empty? || line.start_with?("#")
+
+      if previous_line && line <= previous_line && options.should_check_sorted
+        errors << {
+          message: "Line is duplicated or out of sequence at #{path}:#{index + 1}",
+          code: "ignore_file_not_in_sequence",
+          file: path,
+          line: index + 1,
+        }
+      end
+
+      previous_line = line
+
+      if line.include?("*")
+        patterns << line
+      else
+        files << line
+      end
+    end
+
+    Struct.new(:patterns, :files, :errors).new(patterns, files, errors)
+  end
+
+  def parse_validowners(path)
+    begin
+      IO.readlines(path).map(&:chomp)
+    rescue Errno::ENOENT
+      nil
+    end
+  end
 end
 
-def parse_unownedignore_file(options)
-  lines = begin
-            IO.readlines(CODEOWNERS_IGNORE_PATH).map(&:chomp)
-          rescue Errno::ENOENT
-            []
-          end
+class Repository
+  CODEOWNERS_PATHS = [
+    "CODEOWNERS",
+    "docs/CODEOWNERS",
+    ".github/CODEOWNERS",
+  ].freeze
 
-  patterns = Set.new
-  files = Set.new
-  previous_line = nil
+  # The repository directory is always the current directory.
+  # Maybe that could be changed one day.
 
-  errors = []
-
-  lines.each_with_index do |line, index|
-    next if line.empty? || line.start_with?("#")
-
-    if previous_line && line <= previous_line && options.should_check_sorted
-      errors << {
-        message: "Line is duplicated or out of sequence at #{CODEOWNERS_IGNORE_PATH}:#{index + 1}",
-        code: "ignore_file_not_in_sequence",
-        file: CODEOWNERS_IGNORE_PATH,
-        line: index + 1,
-      }
-    end
-
-    previous_line = line
-
-    if line.include?("*")
-      patterns << line
-    else
-      files << line
-    end
+  def codeowners_file
+    @codeowners_file ||= find_codeowners_file
   end
 
-  Struct.new(:patterns, :files, :errors).new(patterns, files, errors)
+  def codeowners_ignore_file
+    @codeowners_ignore_file ||= codeowners_file + ".ignore"
+  end
+
+  def validowners_file
+    @validowners_file ||= codeowners_file.sub(/CODEOWNERS$/, "VALIDOWNERS")
+  end
+
+  def codeowners_entries
+    @codeowners_entries ||= Parsers.new.parse_codeowners_file(codeowners_file)
+  end
+
+  def ignore_entries(options)
+    @ignore_entries ||= Parsers.new.parse_ignore_file(codeowners_ignore_file, options)
+  end
+
+  def validowners_entries
+    @validowners_entries ||= Parsers.new.parse_validowners(validowners_file)
+  end
+
+  private
+
+  # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
+  def find_codeowners_file
+    CODEOWNERS_PATHS.find do |path|
+      File.exist?(path)
+    end || CODEOWNERS_PATHS.last
+  end
 end
 
 def check_sorted(owner_entries)
@@ -316,15 +366,11 @@ def check_indent(owner_entries)
   Struct.new(:errors).new(errors)
 end
 
-def check_valid_owners(owner_entries)
+def check_valid_owners(repo, owner_entries)
   # This is just to catch typos.
   # We could look up against github, of course.
   # For now, hard-wired is better than nothing.
-  valid_owners = begin
-                   IO.readlines(VALIDOWNERS_PATH).map(&:chomp)
-                 rescue Errno::ENOENT
-                   nil
-                 end
+  valid_owners = repo.validowners_entries
 
   errors = []
 
@@ -466,10 +512,10 @@ end
 
 # Warns if there are entries in the ignore file that are now owned
 # Errors if there are files that don't have an owner (except if the file is included in ignore)
-def check_unowned_files(unowned_files, options)
+def check_unowned_files(repo, unowned_files, options)
   unowned_files = Set.new(unowned_files)
 
-  parsed = parse_unownedignore_file(options)
+  parsed = repo.ignore_entries(options)
 
   warnings = []
   errors = [*parsed.errors]
@@ -494,7 +540,7 @@ def check_unowned_files(unowned_files, options)
   non_ignored_files.sort.each do |file|
     errors << {
       code: "non_ignored_files",
-      message: "Please add this file to #{CODEOWNERS_PATH}: #{file}", # This file does not have an owner
+      message: "Please add this file to #{repo.codeowners_file}: #{file}", # This file does not have an owner
       unowned: file,
     }
   end
@@ -503,7 +549,7 @@ def check_unowned_files(unowned_files, options)
   unused_ignores.sort.each do |unused_ignore|
     warnings << {
       code: "unused_ignore",
-      message: "The following entry in #{CODEOWNERS_IGNORE_PATH} doesn't match any unowned files and should be removed: #{unused_ignore}", # Obsolete entry
+      message: "The following entry in #{repo.codeowners_ignore_file} doesn't match any unowned files and should be removed: #{unused_ignore}", # Obsolete entry
       unused_ignore: unused_ignore,
     }
   end
@@ -511,7 +557,7 @@ def check_unowned_files(unowned_files, options)
   Struct.new(:warnings, :errors).new(warnings, errors)
 end
 
-def run_all_checks(parse_results, owner_entries, options)
+def run_all_checks(repo, parse_results, owner_entries, options)
   warnings = []
   errors = []
 
@@ -528,7 +574,7 @@ def run_all_checks(parse_results, owner_entries, options)
   end
 
   if options.should_check_valid_owners
-    r = check_valid_owners(owner_entries)
+    r = check_valid_owners(repo, owner_entries)
     errors.concat(r.errors)
   end
 
@@ -536,7 +582,7 @@ def run_all_checks(parse_results, owner_entries, options)
 
   if options.check_unowned
     unowned = find_unowned_files(owner_entries, all_files)
-    r = check_unowned_files(unowned, options)
+    r = check_unowned_files(repo, unowned, options)
     warnings.concat(r.warnings)
     errors.concat(r.errors)
   end
@@ -582,8 +628,12 @@ end
 
 options = GetOptions.new(ARGV)
 
-parse_results = parse_codeowners_file
+repo = Repository.new
+
+parse_results = repo.codeowners_entries
 entries = parse_results.entries
+# parse_results.errors is handled by run_all_checks
+
 owner_entries = entries.select { |entry| entry.is_a?(OwnerEntry) }
 
 if options.who_owns
@@ -599,7 +649,7 @@ end
 
 # CHECK MODE
 
-r = run_all_checks(parse_results, owner_entries, options)
+r = run_all_checks(repo, parse_results, owner_entries, options)
 
 if options.strict
   r.errors.concat(r.warnings)

--- a/spec/test_helpers.rb
+++ b/spec/test_helpers.rb
@@ -10,7 +10,7 @@ module TestHelpers
       "..",
       "bin",
       "check-codeowners",
-      )
+    )
   )
 
   HELP_MESSAGE = "For help, see https://github.com/zendesk/setup-check-codeowners/blob/main/Usage.md\n"
@@ -61,6 +61,7 @@ module TestHelpers
         File.open(path, 'w') { }
       end
 
+      # Untested: putting these files in the root, or in "docs".
       write_file(dir, ".github/CODEOWNERS", @codeowners)
       write_file(dir, ".github/CODEOWNERS.ignore", @codeowners_ignore)
       write_file(dir, ".github/VALIDOWNERS", @valid_owners)


### PR DESCRIPTION
Trying to make the code a bit more maintainable. Note that the tests are essentially unchanged.

The second commit introduces two classes, "Parsers" and "repo", to wrap several of the methods which were previously cluttering "main".

There is also a new (as yet untested) feature, whereby `CODEOWNERS` can be in `.` or `docs/` or `.github/`, as per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
