### PR TITLE
Debug fix

### DIFF
--- a/bin/check-codeowners
+++ b/bin/check-codeowners
@@ -49,8 +49,8 @@ module CheckCodeowners
 
       if options.debug
         output.merge!(
-          entries: report.codeowners.entries,
-          owner_entries: report.codeowners.owner_entries,
+          entries: repo.codeowners.entries,
+          owner_entries: repo.codeowners.owner_entries,
           all_files: check_results.all_files,
           match_map: check_results.match_map,
         )

--- a/bin/check-codeowners
+++ b/bin/check-codeowners
@@ -17,20 +17,20 @@ module CheckCodeowners
     end
 
     def show_checks
-      r = Checks.new(repo, options).results
+      check_results = Checks.new(repo, options).results
 
       if options.strict
-        r.errors.concat(r.warnings)
-        r.warnings = []
+        check_results.errors.concat(check_results.warnings)
+        check_results.warnings = []
       end
 
       if options.show_json
-        show_checks_json(r)
+        show_checks_json(check_results)
       else
-        show_checks_text(r)
+        show_checks_text(check_results)
       end
 
-      @has_errors = r.errors.any?
+      @has_errors = check_results.errors.any?
     end
 
     def errors?
@@ -41,18 +41,18 @@ module CheckCodeowners
 
     attr_reader :repo, :options
 
-    def show_checks_json(r)
+    def show_checks_json(check_results)
       output = {
-        errors: r.errors,
-        warnings: r.warnings
+        errors: check_results.errors,
+        warnings: check_results.warnings
       }
 
       if options.debug
         output.merge!(
           entries: report.codeowners.entries,
           owner_entries: report.codeowners.owner_entries,
-          all_files: r.all_files,
-          match_map: r.match_map,
+          all_files: check_results.all_files,
+          match_map: check_results.match_map,
         )
       end
 
@@ -60,11 +60,11 @@ module CheckCodeowners
       puts JSON.pretty_generate(output)
     end
 
-    def show_checks_text(r)
-      r.errors.each { |item| puts "ERROR: #{item[:message]}" }
-      r.warnings.each { |item| puts "WARNING: #{item[:message]}" }
+    def show_checks_text(check_results)
+      check_results.errors.each { |item| puts "ERROR: #{item[:message]}" }
+      check_results.warnings.each { |item| puts "WARNING: #{item[:message]}" }
 
-      if r.errors.any? || r.warnings.any?
+      if check_results.errors.any? || check_results.warnings.any?
         puts "For help, see https://github.com/zendesk/setup-check-codeowners/blob/main/Usage.md"
       end
     end

--- a/spec/debug_spec.rb
+++ b/spec/debug_spec.rb
@@ -1,0 +1,36 @@
+require_relative './test_helpers'
+
+require 'json'
+
+RSpec.configure { |c| c.include TestHelpers }
+
+RSpec.describe "check-codeowners --debug" do
+
+  before do
+    setup
+  end
+
+  it "can debug" do
+    create_file "x1"
+    create_file "x2"
+    create_file "y"
+    add_codeowners "x* @foo/bar"
+
+    r0 = run "--json", "--brute-force"
+    expect(r0.status).to be_success
+    data0 = JSON.parse(r0.stdout)
+
+    r1 = run "--debug", "--json", "--brute-force"
+
+    aggregate_failures do
+      expect(r1.status).to be_success
+      expect(r1.stderr).to eq("")
+    end
+
+    # --debug output isn't documented, so it's not important that it's exactly these keys,
+    # but it's a canary in case the output changes unexpectedly.
+    data1 = JSON.parse(r1.stdout)
+    expect(data1.keys - data0.keys).to contain_exactly("entries", "owner_entries", "all_files", "match_map")
+  end
+
+end

--- a/src/lib/check_codeowners/check_runner.rb
+++ b/src/lib/check_codeowners/check_runner.rb
@@ -6,20 +6,20 @@ module CheckCodeowners
     end
 
     def show_checks
-      r = Checks.new(repo, options).results
+      check_results = Checks.new(repo, options).results
 
       if options.strict
-        r.errors.concat(r.warnings)
-        r.warnings = []
+        check_results.errors.concat(check_results.warnings)
+        check_results.warnings = []
       end
 
       if options.show_json
-        show_checks_json(r)
+        show_checks_json(check_results)
       else
-        show_checks_text(r)
+        show_checks_text(check_results)
       end
 
-      @has_errors = r.errors.any?
+      @has_errors = check_results.errors.any?
     end
 
     def errors?
@@ -30,18 +30,18 @@ module CheckCodeowners
 
     attr_reader :repo, :options
 
-    def show_checks_json(r)
+    def show_checks_json(check_results)
       output = {
-        errors: r.errors,
-        warnings: r.warnings
+        errors: check_results.errors,
+        warnings: check_results.warnings
       }
 
       if options.debug
         output.merge!(
           entries: report.codeowners.entries,
           owner_entries: report.codeowners.owner_entries,
-          all_files: r.all_files,
-          match_map: r.match_map,
+          all_files: check_results.all_files,
+          match_map: check_results.match_map,
         )
       end
 
@@ -49,11 +49,11 @@ module CheckCodeowners
       puts JSON.pretty_generate(output)
     end
 
-    def show_checks_text(r)
-      r.errors.each { |item| puts "ERROR: #{item[:message]}" }
-      r.warnings.each { |item| puts "WARNING: #{item[:message]}" }
+    def show_checks_text(check_results)
+      check_results.errors.each { |item| puts "ERROR: #{item[:message]}" }
+      check_results.warnings.each { |item| puts "WARNING: #{item[:message]}" }
 
-      if r.errors.any? || r.warnings.any?
+      if check_results.errors.any? || check_results.warnings.any?
         puts "For help, see https://github.com/zendesk/setup-check-codeowners/blob/main/Usage.md"
       end
     end

--- a/src/lib/check_codeowners/check_runner.rb
+++ b/src/lib/check_codeowners/check_runner.rb
@@ -38,8 +38,8 @@ module CheckCodeowners
 
       if options.debug
         output.merge!(
-          entries: report.codeowners.entries,
-          owner_entries: report.codeowners.owner_entries,
+          entries: repo.codeowners.entries,
+          owner_entries: repo.codeowners.owner_entries,
           all_files: check_results.all_files,
           match_map: check_results.match_map,
         )


### PR DESCRIPTION
`check-codeowners` has a `--debug` option, which dumps a load of internal calculations out as json. This tiny section of code (a) had a bug and (b) didn't have any test coverage.

Bug fix and test coverage, and also rename a variable for clarity.
