### PR TITLE
prompt users to add full paths to avoid accidents

### DIFF
--- a/bin/check-codeowners
+++ b/bin/check-codeowners
@@ -188,7 +188,7 @@ module CheckCodeowners
       non_ignored_files.sort.each do |file|
         errors << {
           code: "non_ignored_files",
-          message: "Please add this file to #{repo.codeowners.path}: #{file}", # This file does not have an owner
+          message: "Please add this file to #{repo.codeowners.path}: /#{file}", # This file does not have an owner
           unowned: file,
         }
       end

--- a/spec/checking_mode_spec.rb
+++ b/spec/checking_mode_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "check-codeowners checking mode" do
       r = run "--check-unowned"
       aggregate_failures do
         expect(r.status.exitstatus).to eq(1)
-        expect(r.stdout).to eq("ERROR: Please add this file to .github/CODEOWNERS: unowned\n" + help_message)
+        expect(r.stdout).to eq("ERROR: Please add this file to .github/CODEOWNERS: /unowned\n" + help_message)
         expect(r.stderr).to eq("")
       end
     end

--- a/src/lib/check_codeowners/checks.rb
+++ b/src/lib/check_codeowners/checks.rb
@@ -115,7 +115,7 @@ module CheckCodeowners
       non_ignored_files.sort.each do |file|
         errors << {
           code: "non_ignored_files",
-          message: "Please add this file to #{repo.codeowners.path}: #{file}", # This file does not have an owner
+          message: "Please add this file to #{repo.codeowners.path}: /#{file}", # This file does not have an owner
           unowned: file,
         }
       end


### PR DESCRIPTION
if a user add `.rubocop.yml` as an example they'd end up owning all `.rubocop.yml` files in all directories