### PR TITLE
Avoid having to call `git` for matching if possible

### DIFF
--- a/bin/check-codeowners
+++ b/bin/check-codeowners
@@ -371,12 +371,47 @@ module CheckCodeowners
     end
 
     def check_individual_patterns
-      # Slow but thorough: use git to check which files each individual pattern matches
-      # May not scale well!
+      fast_matches, slow_patterns = find_fast_matches(owner_entries.map(&:pattern))
+      slow_matches = find_slow_matches(slow_patterns)
+      collate(fast_matches.merge(slow_matches))
+    end
 
-      match_map = {}
-      warnings = []
+    def find_fast_matches(patterns)
+      # Fast match (not using git to do the matching) "simple" patterns:
+      #   /foo/bar (where that file exists) => matches exactly that file
+      #   /foo/bar/ (where at least one file has that prefix) => matches those files
 
+      # Everything else is collected into "slow_patterns", for matching via `git`
+
+      all_files = Repository::GitLs.new.all_files # Haven't we already got this data?
+      fast_matches_collection = {}
+      slow_patterns = []
+
+      patterns.each do |pattern|
+        if pattern.match?(/\A(\/[^?*\[]+)*\/\z/)
+          pattern_without_slash = pattern[1..-1]
+          prefix_matches = all_files.select { |path| path.start_with?(pattern_without_slash) }
+          if prefix_matches.any?
+            fast_matches_collection[pattern] = prefix_matches
+            next
+          end
+        end
+
+        if pattern.match?(/\A(\/[^?*\[]+)+\z/)
+          pattern_without_slash = pattern[1..-1]
+          if all_files.include?(pattern_without_slash)
+            fast_matches_collection[pattern] = [pattern_without_slash]
+            next
+          end
+        end
+
+        slow_patterns << pattern
+      end
+
+      [fast_matches_collection, slow_patterns]
+    end
+
+    def find_slow_matches(patterns)
       # According to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners ,
       # CODEOWNERS patterns are _quite like_ (but not the same as) the
       # patterns used by "gitignore", so we're going to use git itself to
@@ -395,11 +430,14 @@ module CheckCodeowners
 
       # Which gitignore patterns we need match results for: all the
       # CODEOWNERS patterns, plus the `/* -> /*/**` additions.
-      patterns = owner_entries.map(&:pattern)
       patterns += patterns.select { |patt| patt.end_with?("/*") }.map { |p| "#{p}/**" }
 
-      # Get a hash of { gitignore_pattern => [files matching it] }
-      matched_files_collection = MultiGitLsRunner.new(patterns).run
+      MultiGitLsRunner.new(patterns).run
+    end
+
+    def collate(matched_files_collection)
+      match_map = {}
+      warnings = []
 
       owner_entries.each do |entry|
         matched_files = matched_files_collection[entry.pattern]

--- a/src/lib/check_codeowners/individual_pattern_checker.rb
+++ b/src/lib/check_codeowners/individual_pattern_checker.rb
@@ -25,12 +25,47 @@ module CheckCodeowners
     end
 
     def check_individual_patterns
-      # Slow but thorough: use git to check which files each individual pattern matches
-      # May not scale well!
+      fast_matches, slow_patterns = find_fast_matches(owner_entries.map(&:pattern))
+      slow_matches = find_slow_matches(slow_patterns)
+      collate(fast_matches.merge(slow_matches))
+    end
 
-      match_map = {}
-      warnings = []
+    def find_fast_matches(patterns)
+      # Fast match (not using git to do the matching) "simple" patterns:
+      #   /foo/bar (where that file exists) => matches exactly that file
+      #   /foo/bar/ (where at least one file has that prefix) => matches those files
 
+      # Everything else is collected into "slow_patterns", for matching via `git`
+
+      all_files = Repository::GitLs.new.all_files # Haven't we already got this data?
+      fast_matches_collection = {}
+      slow_patterns = []
+
+      patterns.each do |pattern|
+        if pattern.match?(/\A(\/[^?*\[]+)*\/\z/)
+          pattern_without_slash = pattern[1..-1]
+          prefix_matches = all_files.select { |path| path.start_with?(pattern_without_slash) }
+          if prefix_matches.any?
+            fast_matches_collection[pattern] = prefix_matches
+            next
+          end
+        end
+
+        if pattern.match?(/\A(\/[^?*\[]+)+\z/)
+          pattern_without_slash = pattern[1..-1]
+          if all_files.include?(pattern_without_slash)
+            fast_matches_collection[pattern] = [pattern_without_slash]
+            next
+          end
+        end
+
+        slow_patterns << pattern
+      end
+
+      [fast_matches_collection, slow_patterns]
+    end
+
+    def find_slow_matches(patterns)
       # According to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners ,
       # CODEOWNERS patterns are _quite like_ (but not the same as) the
       # patterns used by "gitignore", so we're going to use git itself to
@@ -49,11 +84,14 @@ module CheckCodeowners
 
       # Which gitignore patterns we need match results for: all the
       # CODEOWNERS patterns, plus the `/* -> /*/**` additions.
-      patterns = owner_entries.map(&:pattern)
       patterns += patterns.select { |patt| patt.end_with?("/*") }.map { |p| "#{p}/**" }
 
-      # Get a hash of { gitignore_pattern => [files matching it] }
-      matched_files_collection = MultiGitLsRunner.new(patterns).run
+      MultiGitLsRunner.new(patterns).run
+    end
+
+    def collate(matched_files_collection)
+      match_map = {}
+      warnings = []
 
       owner_entries.each do |entry|
         matched_files = matched_files_collection[entry.pattern]


### PR DESCRIPTION
tbh I thought that the code already did this. Turns out I'd just thought about it, not implemented it.

Pre-PR, the tool uses the slow but thorough approach of calling `git ls-files` _for each individual pattern_ to find which files match that pattern. Thus the runtime scales with the number of CODEOWNERS lines. Zendesk help-center currently has > 1000 lines of CODEOWNERS, which means > 1000 calls to `git ls-files`, which makes this tool slow (> 10 seconds runtime).

For the more complex patterns (e.g. those involving `*`), calling `git ls-files` is a reasonable approach. But for some patterns – the vast majority of help-center's entries – a much simpler, faster approach can be used:

 * for patterns starting and ending with `/`, and not containing `* ? [` (example: `/app/controllers/`), we can use a simple string-prefix match against the list of all files in the repo
 * for patterns starting but _not_ ending with `/`, and not containing `* ? [` (example: `/app/controllers/my_controller.rb`), we can use a single-entry-exact-match against the list of files

Everything else, we still send to `git ls-files` for detailed checking.

In `help-center` this means that the list of calls to `git` drops by about a factor of 10, and the runtime drops accordingly, down to about 1.7 seconds.

No test changes, since this is a non-functional change.
