### PR TITLE
Rename --brute-force to --find-no-matches

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -20,7 +20,7 @@ The exit status is 2 if there were any errors, or 0 otherwise.
 
 You can also get the output as json with `--json`.
 
-The remaining options control which checks run: for the full set, use `--brute-force --check-unowned --strict`.
+The remaining options control which checks run: for the full set, use `--find-no-matches --check-unowned --strict`.
 
 See [Errors and warnings](#errors-and-warnings) for a description of the checks that are run.
 

--- a/bin/check-codeowners
+++ b/bin/check-codeowners
@@ -235,7 +235,7 @@ module CheckCodeowners
                     repo.git_ls.all_files.sort
                   end
 
-      match_map = if options.find_redundant_ignores
+      match_map = if options.find_no_matches
                     warnings.concat(repo.individual_pattern_checker.warnings)
                     repo.individual_pattern_checker.match_map
                   end
@@ -253,7 +253,7 @@ module CheckCodeowners
       @debug = false
       @show_json = false
       @strict = false
-      @find_redundant_ignores = false
+      @find_no_matches = false
       @who_owns = false
       @files_owned = false
       @check_unowned = false
@@ -264,14 +264,14 @@ module CheckCodeowners
       validate
     end
 
-    attr_reader :debug, :show_json, :strict, :find_redundant_ignores,
+    attr_reader :debug, :show_json, :strict, :find_no_matches,
                 :who_owns, :files_owned,
                 :check_unowned, :should_check_indent, :should_check_sorted, :should_check_valid_owners,
                 :args
 
     private
 
-    attr_writer :debug, :show_json, :strict, :find_redundant_ignores,
+    attr_writer :debug, :show_json, :strict, :find_no_matches,
                 :who_owns, :files_owned,
                 :check_unowned, :should_check_indent, :should_check_sorted, :should_check_valid_owners,
                 :args
@@ -286,8 +286,8 @@ module CheckCodeowners
         opts.on("-s", "--strict", "Treat warnings as errors") do
           self.strict = true
         end
-        opts.on("-b", "--brute-force", "Find entries which do not match any files") do
-          self.find_redundant_ignores = true
+        opts.on("--find-no-matches", "Find entries which do not match any files") do
+          self.find_no_matches = true
         end
         opts.on("--no-check-indent", "Do not require equal indenting") do |value|
           self.should_check_indent = value
@@ -542,7 +542,7 @@ module CheckCodeowners
 
     def files_owned
       results = repo.git_ls.all_files.map do |file|
-        # We don't *have* to brute force every pattern - we could instead
+        # We don't *have* to check every pattern - we could instead
         # run git ls-files per owner, not per pattern. But we already have
         # the code, so it's convenient.
         # Discards warnings

--- a/spec/checking_mode_spec.rb
+++ b/spec/checking_mode_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "check-codeowners checking mode" do
     end
 
     it "warns" do
-      r = run "--brute-force"
+      r = run "--find-no-matches"
       aggregate_failures do
         expect(r.status.exitstatus).to eq(0)
         expect(r.stdout).to eq("WARNING: Pattern foo at .github/CODEOWNERS:1 doesn't match any files\n" + help_message)
@@ -56,7 +56,7 @@ RSpec.describe "check-codeowners checking mode" do
     end
 
     it "turns warnings into errors in --strict mode" do
-      r = run "--brute-force", "--strict"
+      r = run "--find-no-matches", "--strict"
       aggregate_failures do
         expect(r.status.exitstatus).to eq(1)
         expect(r.stdout).to eq("ERROR: Pattern foo at .github/CODEOWNERS:1 doesn't match any files\n" + help_message)
@@ -66,7 +66,7 @@ RSpec.describe "check-codeowners checking mode" do
 
     it "can be satisifed" do
       create_file("foo")
-      expect_silent_success { run "--brute-force" }
+      expect_silent_success { run "--find-no-matches" }
     end
 
   end

--- a/spec/debug_spec.rb
+++ b/spec/debug_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe "check-codeowners --debug" do
     create_file "y"
     add_codeowners "x* @foo/bar"
 
-    r0 = run "--json", "--brute-force"
+    r0 = run "--json", "--find-no-matches"
     expect(r0.status).to be_success
     data0 = JSON.parse(r0.stdout)
 
-    r1 = run "--debug", "--json", "--brute-force"
+    r1 = run "--debug", "--json", "--find-no-matches"
 
     aggregate_failures do
       expect(r1.status).to be_success

--- a/src/lib/check_codeowners/checks.rb
+++ b/src/lib/check_codeowners/checks.rb
@@ -162,7 +162,7 @@ module CheckCodeowners
                     repo.git_ls.all_files.sort
                   end
 
-      match_map = if options.find_redundant_ignores
+      match_map = if options.find_no_matches
                     warnings.concat(repo.individual_pattern_checker.warnings)
                     repo.individual_pattern_checker.match_map
                   end

--- a/src/lib/check_codeowners/get_options.rb
+++ b/src/lib/check_codeowners/get_options.rb
@@ -6,7 +6,7 @@ module CheckCodeowners
       @debug = false
       @show_json = false
       @strict = false
-      @find_redundant_ignores = false
+      @find_no_matches = false
       @who_owns = false
       @files_owned = false
       @check_unowned = false
@@ -17,14 +17,14 @@ module CheckCodeowners
       validate
     end
 
-    attr_reader :debug, :show_json, :strict, :find_redundant_ignores,
+    attr_reader :debug, :show_json, :strict, :find_no_matches,
                 :who_owns, :files_owned,
                 :check_unowned, :should_check_indent, :should_check_sorted, :should_check_valid_owners,
                 :args
 
     private
 
-    attr_writer :debug, :show_json, :strict, :find_redundant_ignores,
+    attr_writer :debug, :show_json, :strict, :find_no_matches,
                 :who_owns, :files_owned,
                 :check_unowned, :should_check_indent, :should_check_sorted, :should_check_valid_owners,
                 :args
@@ -39,8 +39,8 @@ module CheckCodeowners
         opts.on("-s", "--strict", "Treat warnings as errors") do
           self.strict = true
         end
-        opts.on("-b", "--brute-force", "Find entries which do not match any files") do
-          self.find_redundant_ignores = true
+        opts.on("--find-no-matches", "Find entries which do not match any files") do
+          self.find_no_matches = true
         end
         opts.on("--no-check-indent", "Do not require equal indenting") do |value|
           self.should_check_indent = value

--- a/src/lib/check_codeowners/reports.rb
+++ b/src/lib/check_codeowners/reports.rb
@@ -27,7 +27,7 @@ module CheckCodeowners
 
     def files_owned
       results = repo.git_ls.all_files.map do |file|
-        # We don't *have* to brute force every pattern - we could instead
+        # We don't *have* to check every pattern - we could instead
         # run git ls-files per owner, not per pattern. But we already have
         # the code, so it's convenient.
         # Discards warnings


### PR DESCRIPTION
The old name was terrible. The new name is much closer to what it's actually for.
