### PR TITLE
Invalid owner

### DIFF
--- a/bin/check-codeowners
+++ b/bin/check-codeowners
@@ -139,7 +139,7 @@ module CheckCodeowners
           bad_owners.each do |bad_owner|
             errors << {
               code: "invalid_owner",
-              message: "Invalid owner #{bad_owner} at #{entry.file}:#{entry.line_number}",
+              message: "Invalid owner #{bad_owner} at #{entry.file}:#{entry.line_number}, not present in .github/VALIDOWNERS",
               bad_owner: bad_owner,
               entry: entry
             }

--- a/spec/checking_mode_spec.rb
+++ b/spec/checking_mode_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "check-codeowners checking mode" do
 
         aggregate_failures do
           expect(r.status.exitstatus).to eq(1)
-          expect(r.stdout).to eq("ERROR: Invalid owner @org/team1 at .github/CODEOWNERS:1\n" + help_message)
+          expect(r.stdout).to eq("ERROR: Invalid owner @org/team1 at .github/CODEOWNERS:1, not present in .github/VALIDOWNERS\n" + help_message)
           expect(r.stderr).to eq("")
         end
       end

--- a/src/lib/check_codeowners/checks.rb
+++ b/src/lib/check_codeowners/checks.rb
@@ -66,7 +66,7 @@ module CheckCodeowners
           bad_owners.each do |bad_owner|
             errors << {
               code: "invalid_owner",
-              message: "Invalid owner #{bad_owner} at #{entry.file}:#{entry.line_number}",
+              message: "Invalid owner #{bad_owner} at #{entry.file}:#{entry.line_number}, not present in .github/VALIDOWNERS",
               bad_owner: bad_owner,
               entry: entry
             }


### PR DESCRIPTION
☝️ Clarifies what `Invalid owner` means. 

Saves a few clicks and reading the docs, by making the error message more explicit.