### PR TITLE
CI: Use non-forked actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out latest commit from master (the commit that triggered this event)
-      - uses: zendesk/checkout@v2
+      - uses: actions/checkout@v4
       # Compute the next tag using the continuous scheme (v1, v2, etc)
       - name: Compute release tag
         id: compute_tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
     name: Check no-diff from build
     runs-on: ubuntu-latest
     steps:
-      - uses: zendesk/checkout@v2
-      - uses: zendesk/setup-ruby@v1
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - run: ruby script/no-diff.rb
@@ -24,8 +24,8 @@ jobs:
           - '3.0'
           - '3.1'
     steps:
-      - uses: zendesk/checkout@v2
-      - uses: zendesk/setup-ruby@v1
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -34,7 +34,7 @@ jobs:
     name: Install check-codeowners and show help
     runs-on: ubuntu-latest
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install check-codeowners
         uses: ./
       - name: Show help


### PR DESCRIPTION
We don’t need to use the forked actions anymore.